### PR TITLE
fix search box layout

### DIFF
--- a/third_party/src/default/assets/css/elements/_search.sass
+++ b/third_party/src/default/assets/css/elements/_search.sass
@@ -22,7 +22,6 @@
             color: $COLOR_TEXT
 
         label
-            position: absolute
             overflow: hidden
             right: -40px
 

--- a/third_party/src/default/assets/css/elements/_search.sass
+++ b/third_party/src/default/assets/css/elements/_search.sass
@@ -6,10 +6,6 @@
         z-index: 2
 
     .field
-        position: absolute
-        left: 0
-        top: 0
-        right: 40px
         height: 40px
 
         input

--- a/third_party/src/default/partials/header.hbs
+++ b/third_party/src/default/partials/header.hbs
@@ -2,6 +2,14 @@
     <div class="tsd-page-toolbar">
         <div class="container">
             <div class="table-wrap">
+                <div class="topMenu">
+                    <a href="{{relativeURL "index.html"}}" class="title">{{project.name}}</a>
+                    <div class="links">
+                        {{#each settings.links}}
+                        &emsp;<a href="{{url}}" class="title">{{label}}</a>
+                        {{/each}}
+                    </div>
+                </div>
                 <div class="table-cell" id="tsd-search" data-index="{{relativeURL "assets/js/search.json"}}"
                     data-base="{{relativeURL "./"}}">
                     <div class="field">
@@ -18,14 +26,6 @@
                         <li data-name="{{name}}" data-subtitle="{{subtitle}}"></li>
                         {{/each}}
                     </ul>
-                    <div class="topMenu">
-                        <a href="{{relativeURL "index.html"}}" class="title">{{project.name}}</a>
-                        <div class="links">
-                            {{#each settings.links}}
-                            &emsp;<a href="{{url}}" class="title">{{label}}</a>
-                            {{/each}}
-                        </div>
-                    </div>
                 </div>
 
                 <div class="table-cell" id="tsd-widgets">


### PR DESCRIPTION
currently the search box is hidden behind the project name and the input box is not clickable

this pull-request changes it to make the search box clickable and not hidden behind the project name

before:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/1569131/186454286-a41e290a-8d02-4618-bcc3-b48a30635463.png">


after:
<img width="878" alt="image" src="https://user-images.githubusercontent.com/1569131/186454130-c54115b0-ed1b-4ae5-ba8b-800982935f64.png">
